### PR TITLE
Add CoreEnvProxy Spring Boot project

### DIFF
--- a/CoreEnvProxy/.gitignore
+++ b/CoreEnvProxy/.gitignore
@@ -1,0 +1,19 @@
+/target/
+!.mvn/wrapper/maven-wrapper.jar
+.mvn/wrapper/maven-wrapper.jar
+**/.DS_Store
+
+# IntelliJ IDEA
+.idea/
+*.iml
+
+# Eclipse
+.project
+.classpath
+.settings/
+
+# VS Code
+.vscode/
+
+# Logs
+*.log

--- a/CoreEnvProxy/pom.xml
+++ b/CoreEnvProxy/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>CoreEnvProxy</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>CoreEnvProxy</name>
+    <description>CoreEnvProxy Spring Boot application</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/CoreEnvProxy/src/main/java/com/example/coreenvproxy/CoreEnvProxyApplication.java
+++ b/CoreEnvProxy/src/main/java/com/example/coreenvproxy/CoreEnvProxyApplication.java
@@ -1,0 +1,12 @@
+package com.example.coreenvproxy;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CoreEnvProxyApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CoreEnvProxyApplication.class, args);
+    }
+}

--- a/CoreEnvProxy/src/test/java/com/example/coreenvproxy/CoreEnvProxyApplicationTests.java
+++ b/CoreEnvProxy/src/test/java/com/example/coreenvproxy/CoreEnvProxyApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.coreenvproxy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CoreEnvProxyApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- add a new CoreEnvProxy Spring Boot module with Maven configuration
- include the main application entry point and placeholder resources
- provide a basic JUnit context loading test and Git ignore rules

## Testing
- `mvn -f CoreEnvProxy/pom.xml test` *(fails: unable to download dependencies due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe443d248832e85a496533a8f0b08