### PR TITLE
Add Thymeleaf views and database configuration for CoreEnvProxy

### DIFF
--- a/CoreEnvProxy/pom.xml
+++ b/CoreEnvProxy/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.3.13</version>
         <relativePath/>
     </parent>
 
@@ -23,7 +23,26 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/CoreEnvProxy/src/main/java/com/example/coreenvproxy/controller/PageController.java
+++ b/CoreEnvProxy/src/main/java/com/example/coreenvproxy/controller/PageController.java
@@ -1,0 +1,27 @@
+package com.example.coreenvproxy.controller;
+
+import com.example.coreenvproxy.repository.UserGroupRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class PageController {
+
+    private final UserGroupRepository userGroupRepository;
+
+    public PageController(UserGroupRepository userGroupRepository) {
+        this.userGroupRepository = userGroupRepository;
+    }
+
+    @GetMapping("/")
+    public String index() {
+        return "index";
+    }
+
+    @GetMapping("/home")
+    public String home(Model model) {
+        model.addAttribute("userGroups", userGroupRepository.findAll());
+        return "home";
+    }
+}

--- a/CoreEnvProxy/src/main/java/com/example/coreenvproxy/entity/UserGroup.java
+++ b/CoreEnvProxy/src/main/java/com/example/coreenvproxy/entity/UserGroup.java
@@ -1,0 +1,52 @@
+package com.example.coreenvproxy.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "user_groups")
+public class UserGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(length = 512)
+    private String description;
+
+    protected UserGroup() {
+        // JPA requirement
+    }
+
+    public UserGroup(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/CoreEnvProxy/src/main/java/com/example/coreenvproxy/repository/UserGroupRepository.java
+++ b/CoreEnvProxy/src/main/java/com/example/coreenvproxy/repository/UserGroupRepository.java
@@ -1,0 +1,7 @@
+package com.example.coreenvproxy.repository;
+
+import com.example.coreenvproxy.entity.UserGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
+}

--- a/CoreEnvProxy/src/main/resources/application-mssql.properties
+++ b/CoreEnvProxy/src/main/resources/application-mssql.properties
@@ -1,0 +1,11 @@
+spring.datasource.url=jdbc:sqlserver://localhost:1433;databaseName=CoreEnvProxy;encrypt=true;trustServerCertificate=true
+spring.datasource.username=sa
+spring.datasource.password=YourStrong!Passw0rd
+spring.datasource.driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.defer-datasource-initialization=true
+
+spring.sql.init.mode=always

--- a/CoreEnvProxy/src/main/resources/application.properties
+++ b/CoreEnvProxy/src/main/resources/application.properties
@@ -1,0 +1,22 @@
+spring.application.name=CoreEnvProxy
+
+# Default in-memory H2 database configuration
+spring.datasource.url=jdbc:h2:mem:coreenvproxy;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.defer-datasource-initialization=true
+
+spring.sql.init.mode=always
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+spring.thymeleaf.cache=false
+
+# Uncomment to enable MSSQL profile
+# spring.profiles.active=mssql

--- a/CoreEnvProxy/src/main/resources/data.sql
+++ b/CoreEnvProxy/src/main/resources/data.sql
@@ -1,0 +1,4 @@
+INSERT INTO user_groups (name, description) VALUES
+    ('Administrators', 'Full access to core environment management features.'),
+    ('Developers', 'Access to deployment pipelines and debugging tools.'),
+    ('Auditors', 'Read-only access for compliance and auditing purposes.');

--- a/CoreEnvProxy/src/main/resources/templates/home.html
+++ b/CoreEnvProxy/src/main/resources/templates/home.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>CEP &mdash; User Groups</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            background: #f0f4f8;
+            color: #1f2933;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+        header {
+            background: #1d4ed8;
+            color: #ffffff;
+            padding: 1.5rem 2rem;
+        }
+        main {
+            flex: 1;
+            padding: 2rem;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #ffffff;
+            border-radius: 12px;
+            overflow: hidden;
+            box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+        }
+        th, td {
+            padding: 1rem;
+            text-align: left;
+        }
+        th {
+            background: #e2e8f0;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-size: 0.85rem;
+        }
+        tr:nth-child(even) td {
+            background: #f8fafc;
+        }
+        .empty-state {
+            text-align: center;
+            padding: 3rem;
+            background: #ffffff;
+            border-radius: 12px;
+            box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+        }
+        a.button {
+            display: inline-block;
+            margin-top: 1rem;
+            padding: 0.6rem 1.5rem;
+            border-radius: 999px;
+            background: #1d4ed8;
+            color: #ffffff;
+            text-decoration: none;
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <h1>Core Environment Proxy &mdash; User Groups</h1>
+</header>
+<main>
+    <section th:if="${userGroups.isEmpty()}">
+        <div class="empty-state">
+            <p>No user groups are currently defined.</p>
+            <a class="button" th:href="@{/}">Back to Welcome</a>
+        </div>
+    </section>
+    <section th:if="${!userGroups.isEmpty()}">
+        <table>
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Description</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="group : ${userGroups}">
+                <td th:text="${group.id}">1</td>
+                <td th:text="${group.name}">Example</td>
+                <td th:text="${group.description}">Example Description</td>
+            </tr>
+            </tbody>
+        </table>
+    </section>
+</main>
+</body>
+</html>

--- a/CoreEnvProxy/src/main/resources/templates/index.html
+++ b/CoreEnvProxy/src/main/resources/templates/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Core Environment Proxy</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: Arial, sans-serif;
+            background: #f7f9fc;
+            color: #1f2933;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+        }
+        .container {
+            text-align: center;
+            background: #ffffff;
+            padding: 3rem;
+            border-radius: 16px;
+            box-shadow: 0 10px 40px rgba(15, 23, 42, 0.1);
+        }
+        h1 {
+            margin-bottom: 2rem;
+            font-size: 2rem;
+        }
+        a.button {
+            display: inline-block;
+            padding: 0.75rem 2rem;
+            font-size: 1rem;
+            color: #ffffff;
+            background-color: #2563eb;
+            border-radius: 999px;
+            text-decoration: none;
+            transition: background-color 0.2s ease-in-out;
+        }
+        a.button:hover,
+        a.button:focus {
+            background-color: #1d4ed8;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Welcome to Core Environment Proxy (CEP)</h1>
+    <a class="button" th:href="@{/home}">Enter Home</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- upgrade CoreEnvProxy to Spring Boot 3.3.13 with web, Thymeleaf, and JPA dependencies
- implement JPA entity, repository, and controller to load User Group data from the database
- add Thymeleaf templates and configuration for default H2 usage with optional SQL Server profile

## Testing
- mvn -f CoreEnvProxy/pom.xml test

------
https://chatgpt.com/codex/tasks/task_e_68dffc984094832eb139bf484ca8ea27